### PR TITLE
Patches implemented ... should resolve some open issues.

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -1,6 +1,6 @@
 #ifndef CSVUTILS_VERSION_H__
 #define CSVUTILS_VERSION_H__
 
-void print_version(char *program_name);
+void print_version(const char *program_name);
 
 #endif

--- a/src/csvbreak.c
+++ b/src/csvbreak.c
@@ -403,6 +403,8 @@ make_file_name(const char *name)
 void
 cb1 (void *data, size_t len, void *vp)
 {
+  (void)vp;
+
   if (need_name_resolution) {
     if ((strlen(break_field_name) == len) && !strncmp(break_field_name, data, len)) {
       break_field = current_field + 1;
@@ -437,6 +439,9 @@ cb1 (void *data, size_t len, void *vp)
 void
 cb2 (int c, void *vp) 
 {
+  (void)c;
+  (void)vp;
+
   /* No longer first record when first non-empty record seen */
   if (first_record && current_field > 0) {
     if (write_header)
@@ -556,12 +561,16 @@ main (int argc, char *argv[])
   while ((bytes_read=fread(buf, 1, 1024, infile)) > 0) {
     if (csv_parse(&p, buf, bytes_read, cb1, cb2, NULL) != bytes_read) {
       fprintf(stderr, "Error while parsing file: %s\n", csv_strerror(csv_error(&p)));
+      csv_free(&p);
+      if (infile != stdin) fclose(infile);
       exit(EXIT_FAILURE);
     }
   }
 
   if (csv_fini(&p, cb1, cb2, NULL)) {
     fprintf(stderr, "Error while parsing file: %s\n", csv_strerror(csv_error(&p)));
+    csv_free(&p);
+    if (infile != stdin) fclose(infile);
     exit(EXIT_FAILURE);
   }
 
@@ -570,6 +579,7 @@ main (int argc, char *argv[])
   if (just_print_counts)
     print_counts();
 
+  if (infile != stdin) fclose(infile);
   call_remove_files = 0;
   exit(EXIT_SUCCESS);
 }

--- a/src/csvfix.c
+++ b/src/csvfix.c
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define AUTHORS "Robert Gamble"
 
 /* The name this program was called with */
-char *program_name;
+const char *program_name;
 
 /* The delimiter character */
 char delimiter = CSV_COMMA;
@@ -119,6 +119,7 @@ cb1 (void *s, size_t i, void *outfile)
 void
 cb2 (int c, void *outfile)
 {
+  (void)c;
   fputc('\n', (FILE *)outfile);
   current_field = 0;
 }
@@ -207,7 +208,7 @@ main (int argc, char *argv[])
       outfile = fopen(argv[optind+1], "wb");
       if (outfile == NULL) {
         fprintf(stderr, "Failed to open file %s: %s\n", argv[optind+1], strerror(errno));
-        fclose(infile);
+        if (infile != stdin) fclose(infile);
         exit(EXIT_FAILURE);
       }
     }
@@ -216,8 +217,8 @@ main (int argc, char *argv[])
   while ((i=fread(buf, 1, 1024, infile)) > 0) {
     if (csv_parse(&p, buf, i, cb1, cb2, outfile) != i) {
       fprintf(stderr, "Error parsing file: %s\n", csv_strerror(csv_error(&p)));
-      fclose(infile);
-      fclose(outfile);
+      if (infile != stdin) fclose(infile);
+      if (outfile != stdout) fclose(outfile);
       if (argc - optind == 2) remove(argv[optind]);
       exit(EXIT_FAILURE);
     }
@@ -228,14 +229,14 @@ main (int argc, char *argv[])
 
   if (ferror(infile)) {
     fprintf(stderr, "Error reading from input file");
-    fclose(infile);
-    fclose(outfile);
+    if (infile != stdin) fclose(infile);
+    if (outfile != stdout) fclose(outfile);
     if (argc - optind == 2) remove(argv[argc - optind]);
     exit(EXIT_FAILURE);
   }
 
-  fclose(infile);
-  fclose(outfile);
+  if (infile != stdin) fclose(infile);
+  if (outfile != stdout) fclose(outfile);
   return EXIT_SUCCESS;
 }
 

--- a/src/version.c
+++ b/src/version.c
@@ -9,7 +9,7 @@
 #endif
 
 void
-print_version(char *program_name)
+print_version(const char *program_name)
 {
   fprintf(stderr, "\
 %s (csvutils) %s\n\


### PR DESCRIPTION
Changed argument of `print_version` to `const char*` in `version.h` and `version.c`;
Eliminated `goto` statements;
Added code in many places to free allocated memory where necessary;
Added calls to `regfree` and `pcre_free` in `csvgrep.c`;
Added checks so as to avoid calling `fclose` on `stdin/stdout`;
Added `(void)` casts to avoid warnings about arguments/variables not used.